### PR TITLE
NoteList まわりをリファクタする

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import NoteList from "./NoteList";
 
 const App: React.FunctionComponent = () => {
   const [points, setPoints] = React.useState<Points>([]);
-  const [notes, setNotes] = React.useState([newNote([])]);
+  const [notes, setNotes] = React.useState([newNote()]);
   const [bindingTargetId, setBindingTargetId] = React.useState<BindingTargetId>(
     null
   );

--- a/src/Note.tsx
+++ b/src/Note.tsx
@@ -14,8 +14,9 @@ type Props = Note & {
 
 const Note: React.FunctionComponent<Props> = props => {
   const [content, setContent] = React.useState("New Note");
-  // メモを中間に挿入するイベントハンドラ
-  const insert = React.useCallback(
+
+  // 新しいメモをこのメモの前に挿入するイベントハンドラ
+  const insertBefore = React.useCallback(
     () =>
       props.setNotes(prev => {
         const i = prev.findIndex(n => n.id === props.id);
@@ -23,65 +24,67 @@ const Note: React.FunctionComponent<Props> = props => {
       }),
     [props]
   );
+
   // メモが編集されたときのイベントハンドラ
+  // 入力による変更を DOM に反映しておかないと、HTML に書き出す際に空になる
   const edit = React.useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => setContent(e.target.value),
     []
   );
-  // メモとグラフ上の点を紐づけるボタンのイベントハンドラ
+
+  // メモとグラフ上の点を紐づけるためのイベントハンドラ
   const bind = React.useCallback(() => props.setBindingTargetId(props.id), [
     props
   ]);
+
   // メモを上へ移動するイベントハンドラ
   const up = React.useCallback(
     () =>
       props.setNotes(prev => {
         const i = prev.findIndex(n => n.id === props.id);
-        if (i === 0) return prev;
-        return [
-          ...prev.slice(0, i - 1),
-          prev[i],
-          prev[i - 1],
-          ...prev.slice(i + 1)
-        ];
+        return i === 0
+          ? prev // このメモが先頭であった場合は何もしない
+          : [
+              ...prev.slice(0, i - 1),
+              prev[i],
+              prev[i - 1],
+              ...prev.slice(i + 1)
+            ];
       }),
     [props]
   );
+
   // メモを下へ移動するイベントハンドラ
   const down = React.useCallback(
     () =>
       props.setNotes(prev => {
         const i = prev.findIndex(n => n.id === props.id);
-        if (i === prev.length - 1) return prev;
-        return [
-          ...prev.slice(0, i),
-          prev[i + 1],
-          prev[i],
-          ...prev.slice(i + 2)
-        ];
+        return i === prev.length - 1
+          ? prev // このメモが末尾であった場合は何もしない
+          : [...prev.slice(0, i), prev[i + 1], prev[i], ...prev.slice(i + 2)];
       }),
     [props]
   );
+
   // メモを削除するイベントハンドラ
   const del = React.useCallback(
     () => props.setNotes(prev => prev.filter(n => n.id !== props.id)),
     [props]
   );
+
   return (
-    <div className="note">
-      <div>
-        Num: {props.pointNumber}, ID: {props.id}, color: {noteColor(props.id)}
-        x: {props.x}, y: {props.y} dy: {props.dy}
-      </div>
+    <div style={{ background: noteColor(props.id) }}>
+      id: {props.id}, x: {props.x}, y: {props.y}, dy: {props.dy}, num:
+      {props.pointNumber}
       <div className="action">
-        <span onClick={insert}>+ Insert Above</span>
-        <span onClick={up}>Move Up</span>
+        <button onClick={insertBefore}>+ Insert Above</button>
+        <button onClick={up}>Move Up</button>
       </div>
       <textarea className="content" value={content} onChange={edit}></textarea>
       <div className="action">
-        <span onClick={down}>Move Down</span>
-        <span onClick={bind}>Bind</span>
-        <span onClick={del}>Delete</span>
+        <button onClick={down}>Move Down</button>
+        <button onClick={bind}>Bind</button>
+        <button onClick={del}>Delete</button>
       </div>
     </div>
   );

--- a/src/Note.tsx
+++ b/src/Note.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import { newNote, noteColor } from "./lib/note";
 
-type Props = Note &
-  Nullable<Point> & {
-    dy: number | null;
-    pointNumber: number | null;
-    setNotes: SetNotes;
-    setBindingTargetId: SetBindingTargetId;
-  };
+type Props = Note & {
+  // これらは x が null の場合 null
+  // 現状では表示にしか使われない
+  y: number | null;
+  dy: number | null;
+  pointNumber: number | null;
+
+  setNotes: SetNotes;
+  setBindingTargetId: SetBindingTargetId;
+};
 
 const Note: React.FunctionComponent<Props> = props => {
   const [content, setContent] = React.useState("New Note");

--- a/src/Note.tsx
+++ b/src/Note.tsx
@@ -1,16 +1,13 @@
 import React from "react";
 import { newNote, noteColor } from "./lib/note";
 
-type Props = Note & {
-  // これらは x が null の場合 null
-  // 現状では表示にしか使われない
-  y: number | null;
-  dy: number | null;
-  pointNumber: number | null;
-
-  setNotes: SetNotes;
-  setBindingTargetId: SetBindingTargetId;
-};
+type Props = Note &
+  Nullable<Point> & {
+    dy: number | null;
+    pointNumber: number | null;
+    setNotes: SetNotes;
+    setBindingTargetId: SetBindingTargetId;
+  };
 
 const Note: React.FunctionComponent<Props> = props => {
   const [content, setContent] = React.useState("New Note");

--- a/src/NoteList.tsx
+++ b/src/NoteList.tsx
@@ -15,27 +15,38 @@ const NoteList: React.FunctionComponent<Props> = props => {
     () => props.setNotes(prev => [...prev, newNote(prev)]),
     [props]
   );
-  // x が若い順にメモをソートするイベントハンドラ
-  const order = React.useCallback(() => {
+
+  // x が小さい順にメモをソートするイベントハンドラ
+  // グラフに紐づいていないメモは動かさない
+  const ascendingOrder = React.useCallback(() => {
     props.setNotes(prev => {
       const list = prev.map(n => ({ x: n.x, note: n }));
-      let aboveSample: number | null = null;
+
+      // グラフに紐づいていないメモの x を最新の x に合わせる
+      // 例えば list の x が null, 5, 1, null, null, 3, null であった場合、null, 5, 1, 1, 1, 3, 3 のようにする
+      let latestX: number | null = null;
       for (let i = 0; i < list.length; i++) {
-        if (list[i].x === null) list[i].x = aboveSample;
-        else aboveSample = list[i].x;
+        if (list[i].x === null) {
+          list[i].x = latestX;
+        } else {
+          latestX = list[i].x;
+        }
       }
+
       return list
         .sort((a, b) => {
-          // null は int よりも若い
+          // ソートの詳細なアルゴリズムは不明なため、宣言的かつ網羅的に定義する
+          // 先頭のグラフに紐づいていないメモは動かさない
           if (a.x === null && b.x === null) return 0;
           else if (a.x === null) return -1;
           else if (b.x === null) return 1;
-          // int 同士は通常の比較
+          // 数値同士は昇順に並べ、グラフに紐づいていないメモは動かさない
           else return a.x - b.x;
         })
         .map(e => e.note);
     });
   }, [props]);
+
   const notes = props.notes.map(n => {
     // x が定義域内なら f(x), f'(x) を求める
     let y: number | null = null;
@@ -49,6 +60,7 @@ const NoteList: React.FunctionComponent<Props> = props => {
       y = props.graph.f(n.x);
       dy = props.graph.df(n.x);
     }
+
     return (
       <Note
         key={n.id}
@@ -62,13 +74,14 @@ const NoteList: React.FunctionComponent<Props> = props => {
       />
     );
   });
+
   return (
     <div className="note-list">
-      <div onClick={order}>Order By Time</div>
+      <button onClick={ascendingOrder}>Order By Time</button>
       {notes}
-      <div className="new" onClick={add}>
+      <button className="add" onClick={add}>
         + Add
-      </div>
+      </button>
     </div>
   );
 };

--- a/src/NoteList.tsx
+++ b/src/NoteList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { newNote, noteNumber } from "./lib/note";
+import { newNote, pointNumber } from "./lib/note";
 import Note from "./Note";
 
 type Props = {
@@ -56,7 +56,7 @@ const NoteList: React.FunctionComponent<Props> = props => {
         x={n.x}
         y={y}
         dy={dy}
-        pointNumber={noteNumber(props.notes, n.id)}
+        pointNumber={pointNumber(props.notes, n.id)}
         setNotes={props.setNotes}
         setBindingTargetId={props.setBindingTargetId}
       />

--- a/src/declares.d.ts
+++ b/src/declares.d.ts
@@ -1,6 +1,9 @@
 // aliases
 type SetStateFunc<T> = React.Dispatch<React.SetStateAction<T>>;
 
+// utilities
+type Nullable<T> = { [P in keyof T]: T[P] | null };
+
 // グラフの点
 type Point = { x: number; y: number };
 

--- a/src/declares.d.ts
+++ b/src/declares.d.ts
@@ -1,9 +1,6 @@
 // aliases
 type SetStateFunc<T> = React.Dispatch<React.SetStateAction<T>>;
 
-// utilities
-type Nullable<T> = { [P in keyof T]: T[P] | null };
-
 // グラフの点
 type Point = { x: number; y: number };
 

--- a/src/lib/canvas.ts
+++ b/src/lib/canvas.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import { noteColor, noteNumber } from "./note";
+import { noteColor, pointNumber } from "./note";
 
 const scaleX = 100; // 関数空間の横の長さ
 const scaleY = 100; // 関数空間の縦の長さ
@@ -121,7 +121,7 @@ function drawGraph(
       if (graph && graph.from <= x && x <= graph.to) {
         const y = graph.f(x);
         const y2 = graph.d2f(x);
-        const n = noteNumber(notes, notes[i].id);
+        const n = pointNumber(notes, notes[i].id);
         const color = noteColor(notes[i].id);
         const p = funcToCanvas(canvas, { x: x, y: y });
         ctx.fillStyle = color;
@@ -133,7 +133,7 @@ function drawGraph(
       } else if (prev && prev.from <= x && x <= prev.to) {
         const y = prev.f(x);
         const y2 = prev.d2f(x);
-        const n = noteNumber(notes, notes[i].id);
+        const n = pointNumber(notes, notes[i].id);
         const p = funcToCanvas(canvas, { x: x, y: y });
         ctx.font = `${oldGraphFontSize}px bold ${graphFont}`;
         ctx.fillStyle = oldGraphLineColor;

--- a/src/lib/note.ts
+++ b/src/lib/note.ts
@@ -1,7 +1,9 @@
-// 新しい空のメモを返す
-function newNote(currentNotes: Note[]): Note {
-  const maxId = currentNotes.reduce((a, n) => (a < n.id ? n.id : a), 0);
-  return { id: maxId + 1, x: null };
+// 新しい空のメモを返す関数
+// 引数なしで呼ばれた場合や notes が [] の場合は初期値を返す
+function newNote(notes: Notes = []): Note {
+  if (notes.length) return { id: 1, x: null };
+  const newId = Math.max(...notes.map(n => n.id)) + 1;
+  return { id: newId, x: null };
 }
 
 // TODO: algorithm
@@ -10,14 +12,15 @@ function noteColor(id: number): string {
   return id % 2 === 0 ? "blue" : "red";
 }
 
-// グラフ上の点の番号を求める関数
-// グラフと紐づいている Note のみを対象とし、番号は1から与える
-function noteNumber(notes: Note[], id: number): number | null {
+// 識別子が id なメモと紐づいたグラフ上の点の番号を求める関数
+// 番号は 1 から与えられ、メモが点と紐づいていなかった場合 null が返る
+function pointNumber(notes: Notes, id: Note["id"]): number | null {
   const i = notes
     .filter(n => n.x !== null)
-    .sort((a, b) => (a.x !== null && b.x !== null ? a.x - b.x : 0))
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    .sort((a, b) => a.x! - b.x!)
     .findIndex(n => n.id === id);
-  return i >= 0 ? i + 1 : null;
+  return 0 <= i ? i + 1 : null;
 }
 
-export { newNote, noteColor, noteNumber };
+export { newNote, noteColor, pointNumber };

--- a/src/lib/note.ts
+++ b/src/lib/note.ts
@@ -1,7 +1,7 @@
 // 新しい空のメモを返す関数
 // 引数なしで呼ばれた場合や notes が [] の場合は初期値を返す
 function newNote(notes: Notes = []): Note {
-  if (notes.length) return { id: 1, x: null };
+  if (!notes.length) return { id: 1, x: null };
   const newId = Math.max(...notes.map(n => n.id)) + 1;
   return { id: newId, x: null };
 }


### PR DESCRIPTION
#### ※ #21 に依存しているため、#21 をマージしてからマージすること

#21 との差分: https://github.com/prog-g/dcc-report/compare/mv...refactor-timeline

- `newNote()` の挙動を変更
- `noteNumber()` を `pointNumber()` にリネーム
- `order()` を `ascendingOrder()` にリネーム
- `NoteList.tsx`, `Note.tsx` にコメントを追記
- `NoteList.tsx`, `Note.tsx` の一部 `<div>` を `<button>` に変更