### PR TITLE
グラフボーターの接着の改善 Margin -2px 0 0

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -39,7 +39,7 @@ button {
 .graph-canvas {
   display: block;
   width: 100%;
-  margin: -1px 0;
+  margin: -2px 0 0;
   border: 2px solid #333;
 }
 


### PR DESCRIPTION
## グラフのボーダーがちゃんとくっつくようにする

.graph-info がキャンバスのボーターと隙間なくくっつかない問題は、.graph-info の下ボーター分の空間を取ろうとするために起きている。
よって -2px が、くっつかせるための値として適切なので変更する。

## 下部分のボーダー消失を回避

ダウンロードした後の HTML でキャンバスの画像がボータに被ってしまうことがあるため、下マージンを 0 にする。

<img width="678" alt="image" src="https://user-images.githubusercontent.com/37978051/77755569-e3e05780-7070-11ea-9a09-2c82d6fb6383.png">