### PR TITLE
Fix inline space

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -29,6 +29,7 @@ button {
 }
 
 .graph-info {
+  display: inline-block;
   padding: 0 2px;
   font-size: 90%;
   border: 2px solid #333;
@@ -39,7 +40,6 @@ button {
 .graph-canvas {
   display: block;
   width: 100%;
-  margin: -2px 0 0;
   border: 2px solid #333;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -40,6 +40,8 @@ button {
 .graph-canvas {
   display: block;
   width: 100%;
+  /* see https://github.com/prog-g/dcc-report/pull/33 */
+  margin: -1px 0 0;
   border: 2px solid #333;
 }
 


### PR DESCRIPTION
#29 の問題ですが、ボーダーのせいではなく `.graph-info` が `span` であり、インライン要素であるため、自動的に下に隙間が作られていたために起こっていました。
それの修正です。