### PR TITLE
webpack や stylelint の設定の更新

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,5 +3,6 @@
     "stylelint-config-standard",
     "stylelint-config-recess-order",
     "stylelint-config-prettier"
-  ]
+  ],
+  "ignoreFiles": ["**/*.[tj]s{,x}"]
 }

--- a/src/Note.tsx
+++ b/src/Note.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { newNote, noteColor as notecolor } from "./lib/note";
+import { newNote, noteColor } from "./lib/note";
 
 type Props = Note & {
   // これらは x が null の場合 null
@@ -82,7 +82,7 @@ const Note: React.FunctionComponent<Props> = props => {
     [props]
   );
 
-  const labelColor = { borderColor: notecolor(props.id) };
+  const labelColor = { borderColor: noteColor(props.id) };
   return (
     <div className="note">
       <div className="note-header" style={labelColor}>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,7 @@ module.exports = (env, { mode }) => {
     devtool: dev ? "inline-source-map" : false,
     devServer: {
       contentBase: "./dist",
+      // host: "0.0.0.0", // for debugging on mobile devices
       overlay: true,
       watchContentBase: true
     }


### PR DESCRIPTION
- 実機でのデバッグができるように webpack の設定を更新した
  - webpack.config.js の `host: "0.0.0.0",` のコメントアウトを消せばできる
- stylelint が JS ファイルなどを無視するように設定を更新した
  - `noteColor as notecolor` 問題を解決した