### PR TITLE
ページを閉じようとしたときにアラートを出す

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,3 +4,4 @@ import App from "./App";
 import "./style.css";
 
 ReactDOM.render(<App />, document.getElementById("app"));
+window.onbeforeunload = (): boolean => true;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,4 +4,9 @@ import App from "./App";
 import "./style.css";
 
 ReactDOM.render(<App />, document.getElementById("app"));
-window.onbeforeunload = (): boolean => true;
+
+// ページを閉じようとしたときにアラートを出す
+// null や undefind に評価される値ではアラートが出ないので true をセットする
+window.addEventListener("beforeunload", (e): void => {
+  e.returnValue = true;
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,8 +5,9 @@ import "./style.css";
 
 ReactDOM.render(<App />, document.getElementById("app"));
 
-// ページを閉じようとしたときにアラートを出す
-// null や undefind に評価される値ではアラートが出ないので true をセットする
+// ページを閉じようとしたときに確認プロンプトを表示する
+// see https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#Examples
 window.addEventListener("beforeunload", (e) => {
-  e.returnValue = true;
+  e.preventDefault();
+  e.returnValue = "";
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,6 @@ ReactDOM.render(<App />, document.getElementById("app"));
 
 // ページを閉じようとしたときにアラートを出す
 // null や undefind に評価される値ではアラートが出ないので true をセットする
-window.addEventListener("beforeunload", (e): void => {
+window.addEventListener("beforeunload", (e) => {
   e.returnValue = true;
 });


### PR DESCRIPTION
- ページを閉じようとしたときに、アラートを出すことで編集内容が失われる事故を予防する
- ダウンロードをしてその後ページに内容の変更をしなかった場合などでもアラートがでてしまいうっとしい感じもするが、一度閉じたら再編集できないのでそれくらいしつこくても良いかなと思った