### PR TITLE
グラフの点を縁取りする

### DIFF
--- a/src/lib/canvas.ts
+++ b/src/lib/canvas.ts
@@ -6,6 +6,7 @@ const scaleX = 100; // 関数空間の横の長さ
 const scaleY = 100; // 関数空間の縦の長さ
 const graphLineWidth = 2; // グラフ曲線の描画幅
 const graphPointRadius = 4; // グラフの点の半径
+const graphPointOutlineWidth = 1.5; // グラフの点の縁取りの幅
 const graphFont = "sans-serif"; // グラフで使うフォント
 const graphFontSize = 20; // グラフのフォントサイズ
 const graphLineColor = "#000"; // グラフ曲線の描画色
@@ -124,6 +125,16 @@ function drawGraph(
         const n = pointNumber(notes, notes[i].id);
         const color = noteColor(notes[i].id);
         const p = funcToCanvas(canvas, { x: x, y: y });
+        ctx.fillStyle = graphLineColor;
+        ctx.beginPath();
+        ctx.arc(
+          p.x,
+          p.y,
+          graphPointRadius + graphPointOutlineWidth,
+          0,
+          2 * Math.PI
+        );
+        ctx.fill();
         ctx.fillStyle = color;
         ctx.font = `${graphFontSize}px bold ${graphFont}`;
         ctx.beginPath();


### PR DESCRIPTION
- 縁の色はグラフの線と同じ
- 縁の太さは定数 `graphPointOutlineWidth` で制御 (px)

### サンプル
<img width="1107" alt="スクリーンショット 2020-08-13 20 49 04" src="https://user-images.githubusercontent.com/37978051/90131155-a45ba300-dda6-11ea-8b02-d51a176fd827.png">
