### PR TITLE
タッチするデバイスでグラフを描けるようにする

### DIFF
--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -140,10 +140,11 @@ const Graph: React.FunctionComponent<Props> = (props) => {
         height={height}
         ref={canvasRef}
         onClick={onClick}
-        onMouseDown={onMouseDown}
-        onMouseMove={onMouseMove}
-        onMouseUp={onEndDrawing}
-        onMouseLeave={onEndDrawing}
+        onPointerDown={onMouseDown}
+        onPointerMove={onMouseMove}
+        onPointerUp={onEndDrawing}
+        onPointerLeave={onEndDrawing}
+        onPointerCancel={onEndDrawing}
       />
       <div className="graph-menu">
         <button onClick={clear}>書き直す</button>

--- a/src/style.css
+++ b/src/style.css
@@ -60,6 +60,7 @@ button:active {
 
   /* see https://github.com/prog-g/dcc-report/pull/33 */
   margin: -1px 0 0;
+  touch-action: none;
   border: 2px solid #333;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -60,7 +60,7 @@ button:active {
 
   /* see https://github.com/prog-g/dcc-report/pull/33 */
   margin: -1px 0 0;
-  touch-action: none;
+  touch-action: pinch-zoom;
   border: 2px solid #333;
 }
 


### PR DESCRIPTION
## やったこと

- [x] `PointerEvent` について調査する
- [x] CSSの `touch-action` について調査する
- [x] mouseXX イベントを pointerXX イベントに置換してタッチ対応
- [x] グラフの上の１本指でのスライドでスクロールしなくする（スマホ）
- [x] 実装して動きを確かめてみる

## 関連する issue や PR やドキュメント

fix #70 

- <https://developers.google.com/web/fundamentals/design-and-ux/input/touch?hl=ja>
- <https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events>
- <https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action>

## 備考

- ズーム、２本指でのスクロールを有効にするため、`touch-action: none` でなく `touch-action: pinch-zoom` にする。
- Safari の `touch-action: pinch-zoom` の挙動が怪しい（１本指でのスクロールができてしまうことがあった）。
- スマホでスクロールに切り替わったときに `pointerUp` or `pointerLeave` は呼ばれず、`pointerCancel` が発火する。
