### PR TITLE
スマホ用にcssを修正

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -154,8 +154,8 @@ button:active {
 
 .name-form > label > input {
   flex-grow: 1;
-  margin-left: 4px;
   margin-bottom: 4px;
+  margin-left: 4px;
 }
 
 .download {

--- a/src/style.css
+++ b/src/style.css
@@ -149,12 +149,11 @@ button:active {
 .name-form > label {
   display: flex;
   flex-grow: 1;
-  margin-right: 16px;
+  margin: 0 16px 4px 0;
 }
 
 .name-form > label > input {
   flex-grow: 1;
-  margin-bottom: 4px;
   margin-left: 4px;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -141,6 +141,7 @@ button:active {
 
 .name-form {
   display: flex;
+  flex-wrap: wrap;
   padding-left: 8px;
   margin-top: 4px;
 }
@@ -154,6 +155,7 @@ button:active {
 .name-form > label > input {
   flex-grow: 1;
   margin-left: 4px;
+  margin-bottom: 4px;
 }
 
 .download {


### PR DESCRIPTION
## やったこと
スマホからdcc-reportサイトを閲覧した際に学籍番号と名前の入力部分が画面外にまで飛び出しているのを修正した。

## 関連する issue や PR やドキュメント
#82 
