### PR TITLE
renovateが作ったPRのデプロイをスキップする

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           matrix.script == 'build' &&
           github.event_name == 'push' &&
           github.ref == 'refs/heads/master' &&
+          github.event.head_commit.author.name != 'renovate[bot]' &&
           !contains(github.event.head_commit.message, '[deploy skip]')
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## やったこと

<!-- issue の やること との対応を意識して書く -->

- [x] renovate が作った PR をマージした場合はデプロイが走らないようにした

## 関連する issue や PR やドキュメント

<!-- あれば書く -->

- https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#push
- https://github.community/t/why-is-my-commit-associated-with-the-wrong-person/10199

## 備考

<!-- あれば書く -->

`yarn start` などに関する更新は `yarn build` だけでは様子を確認できないし、renovate が作るもの以外の PR では基本的に `yarn start` などで開発時に動作確認をするため、自動デプロイによるリグレッションをある程度防止できると考えこのようにした。
