### PR TITLE
名前欄スタイルの微修正

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -159,7 +159,9 @@ button:active {
 
 .name-form > label > input {
   flex-grow: 1;
+  padding: 0 2px;
   margin-left: 4px;
+  border: solid 1px #0003;
   border-radius: 8px;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -159,9 +159,9 @@ button:active {
 
 .name-form > label > input {
   flex-grow: 1;
-  padding: 0 2px;
+  padding: 0 4px;
   margin-left: 4px;
-  border: solid 1px #0003;
+  border: solid 1px #555;
   border-radius: 8px;
 }
 


### PR DESCRIPTION
## やったこと

- Chrome の User agent stylesheet によって、名前欄の枠が太くなっているのを打ち消す

⬇︎現状
![Old](https://user-images.githubusercontent.com/37978051/100620208-7e600b80-3361-11eb-96ee-b987326a8485.png)

⬇︎修正後
![image](https://user-images.githubusercontent.com/37978051/100620450-caab4b80-3361-11eb-84f5-95d129fb7a55.png)

- ついでに枠線の色も他所に合わせる
- 名前欄内のテキストが枠の端っこにかなり近くなるので、少しスペースをとる