### PR TITLE
マニュアルがデプロイされない不具合の修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,3 +30,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          enable_jekyll: true


### PR DESCRIPTION
## やったこと

[peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) のバージョンが上がってマニュアルがデプロイされなくなっていたのを修正した。

## 関連する issue や PR やドキュメント

- https://github.com/peaceiris/actions-gh-pages/tree/v3.7.3#%EF%B8%8F-enable-built-in-jekyll-enable_jekyll

<!-- あれば書く -->

## 備考

<!-- あれば書く -->
